### PR TITLE
Increase TWAI rx/tx queue lengths

### DIFF
--- a/ember-can/ember_can.c
+++ b/ember-can/ember_can.c
@@ -44,8 +44,8 @@ static void can_init()
         .rx_io = CAN_RX_GPIO,
         .clkout_io = TWAI_IO_UNUSED,
         .bus_off_io = TWAI_IO_UNUSED,
-        .tx_queue_len = 8,
-        .rx_queue_len = 8,
+        .tx_queue_len = 64,
+        .rx_queue_len = 64,
         .alerts_enabled = TWAI_ALERT_NONE,
         .clkout_divider = 0,
         .intr_flags = ESP_INTR_FLAG_LEVEL1


### PR DESCRIPTION
If the OpenCAN tx scheduler sends more than like 8 messages at once, they're likely to get dropped, because it's queueing them up much faster than they're being sent. This behavior was observed on the motorsports AMS ECU.

Increase the queue lengths to 64. In the future, the TX scheduler should be made more intelligent so that it staggers the transmission of cyclics.

64 is an arbitrary upper limit increase; it's not enough to fully solve the problem.