### PR TITLE
Disable extended CAN IDs

### DIFF
--- a/ember-can/ember_can.c
+++ b/ember-can/ember_can.c
@@ -106,7 +106,6 @@ void CAN_callback_enqueue_tx_message(const uint8_t * const data, const uint8_t l
     /* prepare twai_message_t */
     twai_message_t message = {
         .identifier = id,
-        .extd = true, // todo
         .data_length_code = len,
     };
 


### PR DESCRIPTION
At the moment OpenCAN does not distinguish between normal and extended CAN IDs. For the time being, we will fall back to 11-bit CAN IDs.